### PR TITLE
Change to handle three condition when indenting

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -37,124 +37,124 @@ function leadWsCount(line, tabSize) {
 
 exports.activate = function() {
     vscode.commands.registerCommand('tab', () => {
-        try {
-            const editor = vscode.window.activeTextEditor;
-            if (!editor) {
-                return;
-            }
-            let sel = editor.selection.active;
-            let cursorLine = sel.line;
-            let doc = editor.document;
-
-            let prevLine;
-            for (let i = cursorLine-1; i >= 0; i--) {
-                let l = doc.lineAt(i);
-                if (l.isEmptyOrWhitespace) {
-                    continue;
-                }
-                let txt = l.text;
-                let char1 = txt.charCodeAt(l.firstNonWhitespaceCharacterIndex);
-                let char2 = txt.charCodeAt(l.firstNonWhitespaceCharacterIndex + 1);
-                if ((char1 === 47) && (char2 === 47 || char2 === 42)) { // '//' and '/*'
-                    continue;
-                } else if (char1 === 35) { // #
-                    continue;
-                }
-                prevLine = l;
-                break;
-            }
-            if (!prevLine) {
-                return;
-            }
-            let currLine = doc.lineAt(cursorLine);
-
-            let options = editor.options;
-            let indentSize = options.indentSize;
-            let tabSize = options.tabSize;
-            let insertSpaces = options.insertSpaces;
-
-            let currIndent;
-            let prevIndent;
-            let indentStep;
-
-            currIndent = leadWsCount(currLine, tabSize);
-            prevIndent = leadWsCount(prevLine, tabSize);
-            indentStep = insertSpaces ? indentSize : tabSize;
-
-            let target;
-            if (lineRequiresUnindent(currLine, doc)) {
-                if (lineRequiresNextIndent(prevLine, doc)) {
-                    // example {
-                    // }
-                    target = prevIndent;
-                } else {
-                    //     example
-                    // }
-                    target = prevIndent - indentStep;
-                    if (target < 0) {
-                        target = 0;
-                    }
-                }
-            }
-            else if (lineRequiresNextIndent(prevLine, doc)) {
-                target = prevIndent + indentStep;
-            }
-            else {
-                target = prevIndent;
-            }
-
-            // unify leading whitespace if it contains indents not of our tab/space mode
-            let txt = currLine.text;
-            let end = currLine.firstNonWhitespaceCharacterIndex;
-            let validWs = insertSpaces ? 32 : 9;
-            // diff can be zero here, but we may need to replace spaces with tabs and still have a diff
-            for (let i = 0; i < end; i++) {
-                if (txt.charCodeAt(i) !== validWs) {
-                    // Leading whitespace contains a whitespace char of the opposite type
-                    // Replace the whole whitespace from start of line with the proper number of our
-                    // ws char
-                    editor.edit(function(builder) {
-                        builder.replace(new vscode.Range(cursorLine, 0, cursorLine, end), insertSpaces
-                        ? ' '.repeat(target)
-                        : '\t'.repeat(Math.floor(target/tabSize)));
-                    })
-                    .then(function() {
-                        let sel = editor.selection;
-                        if (!sel.isEmpty) {
-                            editor.selection = new vscode.Selection(sel.end, sel.end);
-                        }
-                    });
-                    return;
-                }
-            }
-
-            let diff = (currIndent - target); // diff is always in spaces
-            if (diff == 0) {
-                // business as usual
-                editor.edit(function(builder) {
-                    builder.insert(editor.selection.active, (
-                        // diff == 0 : Normal indent
-                        insertSpaces? ' '.repeat(-diff) : '\t'.repeat(Math.floor((-diff) / tabSize))
-                    ));
-                });
-            } else if (diff > 0) {
-                // overindented - delete some spaces
-                editor.edit(function(builder) {
-                    builder.insert(new vscode.Position(cursorLine, currIndent), (
-                        // diff < 0 : under-indented, add some spaces
-                        insertSpaces? ' '.repeat(-diff + (diff == 0? 1 : 0)) : '\t'.repeat(Math.floor((-diff) / tabSize) + (diff == 0? 1 : 0))
-                    ));
-                });
-            } else {
-                editor.edit(function(builder) {
-                    builder.insert(new vscode.Position(cursorLine, 0), (
-                        // diff < 0 : under-indented, add some spaces
-                        insertSpaces? ' '.repeat(-diff) : '\t'.repeat(Math.floor((-diff) / tabSize))
-                    ));
-                });
-            }
-        } catch(e) {
-            console.error("Exception:", e);
+    try {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            return;
         }
+        let sel = editor.selection.active;
+        let cursorLine = sel.line;
+        let doc = editor.document;
+
+        let prevLine;
+        for (let i = cursorLine-1; i >= 0; i--) {
+            let l = doc.lineAt(i);
+            if (l.isEmptyOrWhitespace) {
+                continue;
+            }
+            let txt = l.text;
+            let char1 = txt.charCodeAt(l.firstNonWhitespaceCharacterIndex);
+            let char2 = txt.charCodeAt(l.firstNonWhitespaceCharacterIndex + 1);
+            if ((char1 === 47) && (char2 === 47 || char2 === 42)) { // '//' and '/*'
+                continue;
+            } else if (char1 === 35) { // #
+                continue;
+            }
+            prevLine = l;
+            break;
+        }
+        if (!prevLine) {
+            return;
+        }
+        let currLine = doc.lineAt(cursorLine);
+
+        let options = editor.options;
+        let indentSize = options.indentSize;
+        let tabSize = options.tabSize;
+        let insertSpaces = options.insertSpaces;
+
+        let currIndent;
+        let prevIndent;
+        let indentStep;
+
+        currIndent = leadWsCount(currLine, tabSize);
+        prevIndent = leadWsCount(prevLine, tabSize);
+        indentStep = insertSpaces ? indentSize : tabSize;
+
+        let target;
+        if (lineRequiresUnindent(currLine, doc)) {
+            if (lineRequiresNextIndent(prevLine, doc)) {
+                // example {
+                // }
+                target = prevIndent;
+            } else {
+                //     example
+                // }
+                target = prevIndent - indentStep;
+                if (target < 0) {
+                    target = 0;
+                }
+            }
+        }
+        else if (lineRequiresNextIndent(prevLine, doc)) {
+            target = prevIndent + indentStep;
+        }
+        else {
+            target = prevIndent;
+        }
+
+        // unify leading whitespace if it contains indents not of our tab/space mode
+        let txt = currLine.text;
+        let end = currLine.firstNonWhitespaceCharacterIndex;
+        let validWs = insertSpaces ? 32 : 9;
+        // diff can be zero here, but we may need to replace spaces with tabs and still have a diff
+        for (let i = 0; i < end; i++) {
+            if (txt.charCodeAt(i) !== validWs) {
+                // Leading whitespace contains a whitespace char of the opposite type
+                // Replace the whole whitespace from start of line with the proper number of our
+                // ws char
+                editor.edit(function(builder) {
+                    builder.replace(new vscode.Range(cursorLine, 0, cursorLine, end), insertSpaces
+                    ? ' '.repeat(target)
+                    : '\t'.repeat(Math.floor(target/tabSize)));
+                })
+                .then(function() {
+                    let sel = editor.selection;
+                    if (!sel.isEmpty) {
+                        editor.selection = new vscode.Selection(sel.end, sel.end);
+                    }
+                });
+                return;
+            }
+        }
+
+        let diff = (currIndent - target); // diff is always in spaces
+        if (diff == 0) {
+            // business as usual
+            editor.edit(function(builder) {
+                builder.insert(editor.selection.active, (
+                    // diff == 0 : Normal indent
+                    insertSpaces? ' '.repeat(-diff) : '\t'.repeat(Math.floor((-diff) / tabSize))
+                ));
+            });
+        } else if (diff > 0) {
+            // overindented - delete some spaces
+            editor.edit(function(builder) {
+                builder.insert(new vscode.Position(cursorLine, currIndent), (
+                    // diff < 0 : under-indented, add some spaces
+                    insertSpaces? ' '.repeat(-diff + (diff == 0? 1 : 0)) : '\t'.repeat(Math.floor((-diff) / tabSize) + (diff == 0? 1 : 0))
+                ));
+            });
+        } else {
+            editor.edit(function(builder) {
+                builder.insert(new vscode.Position(cursorLine, 0), (
+                    // diff < 0 : under-indented, add some spaces
+                    insertSpaces? ' '.repeat(-diff) : '\t'.repeat(Math.floor((-diff) / tabSize))
+                ));
+            });
+        }
+    } catch(e) {
+        console.error("Exception:", e);
+    }
     });
 }

--- a/extension.js
+++ b/extension.js
@@ -37,121 +37,124 @@ function leadWsCount(line, tabSize) {
 
 exports.activate = function() {
     vscode.commands.registerCommand('tab', () => {
-    try {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            return;
-        }
-        let sel = editor.selection.active;
-        let cursorLine = sel.line;
-        let doc = editor.document;
-
-        let prevLine;
-        for (let i = cursorLine-1; i >= 0; i--) {
-            let l = doc.lineAt(i);
-            if (l.isEmptyOrWhitespace) {
-                continue;
-            }
-            let txt = l.text;
-            let char1 = txt.charCodeAt(l.firstNonWhitespaceCharacterIndex);
-            let char2 = txt.charCodeAt(l.firstNonWhitespaceCharacterIndex + 1);
-            if ((char1 === 47) && (char2 === 47 || char2 === 42)) { // '//' and '/*'
-                continue;
-            } else if (char1 === 35) { // #
-                continue;
-            }
-            prevLine = l;
-            break;
-        }
-        if (!prevLine) {
-            return;
-        }
-        let currLine = doc.lineAt(cursorLine);
-
-        let options = editor.options;
-        let indentSize = options.indentSize;
-        let tabSize = options.tabSize;
-        let insertSpaces = options.insertSpaces;
-
-        let currIndent;
-        let prevIndent;
-        let indentStep;
-
-        currIndent = leadWsCount(currLine, tabSize);
-        prevIndent = leadWsCount(prevLine, tabSize);
-        indentStep = insertSpaces ? indentSize : tabSize;
-
-        let target;
-        if (lineRequiresUnindent(currLine, doc)) {
-            if (lineRequiresNextIndent(prevLine, doc)) {
-                // example {
-                // }
-                target = prevIndent;
-            } else {
-                //     example
-                // }
-                target = prevIndent - indentStep;
-                if (target < 0) {
-                    target = 0;
-                }
-            }
-        }
-        else if (lineRequiresNextIndent(prevLine, doc)) {
-            target = prevIndent + indentStep;
-        }
-        else {
-            target = prevIndent;
-        }
-
-        // unify leading whitespace if it contains indents not of our tab/space mode
-        let txt = currLine.text;
-        let end = currLine.firstNonWhitespaceCharacterIndex;
-        let validWs = insertSpaces ? 32 : 9;
-        // diff can be zero here, but we may need to replace spaces with tabs and still have a diff
-        for (let i = 0; i < end; i++) {
-            if (txt.charCodeAt(i) !== validWs) {
-                // Leading whitespace contains a whitespace char of the opposite type
-                // Replace the whole whitespace from start of line with the proper number of our
-                // ws char
-                editor.edit(function(builder) {
-                    builder.replace(new vscode.Range(cursorLine, 0, cursorLine, end), insertSpaces
-                    ? ' '.repeat(target)
-                    : '\t'.repeat(Math.floor(target/tabSize)));
-                })
-                .then(function() {
-                    let sel = editor.selection;
-                    if (!sel.isEmpty) {
-                        editor.selection = new vscode.Selection(sel.end, sel.end);
-                    }
-                });
+        try {
+            const editor = vscode.window.activeTextEditor;
+            if (!editor) {
                 return;
             }
-        }
+            let sel = editor.selection.active;
+            let cursorLine = sel.line;
+            let doc = editor.document;
 
-        let diff = (currIndent - target); // diff is always in spaces
-        if (diff === 0) {
-            return; // no change
-        }
+            let prevLine;
+            for (let i = cursorLine-1; i >= 0; i--) {
+                let l = doc.lineAt(i);
+                if (l.isEmptyOrWhitespace) {
+                    continue;
+                }
+                let txt = l.text;
+                let char1 = txt.charCodeAt(l.firstNonWhitespaceCharacterIndex);
+                let char2 = txt.charCodeAt(l.firstNonWhitespaceCharacterIndex + 1);
+                if ((char1 === 47) && (char2 === 47 || char2 === 42)) { // '//' and '/*'
+                    continue;
+                } else if (char1 === 35) { // #
+                    continue;
+                }
+                prevLine = l;
+                break;
+            }
+            if (!prevLine) {
+                return;
+            }
+            let currLine = doc.lineAt(cursorLine);
 
-        // business as usual
-        if (diff > 0) {
-            // overindented - delete some spaces
-            editor.edit(function(builder) {
-                builder.delete(new vscode.Range(cursorLine, 0, cursorLine,
-                    insertSpaces ? diff : Math.floor(diff / tabSize)));
-            });
+            let options = editor.options;
+            let indentSize = options.indentSize;
+            let tabSize = options.tabSize;
+            let insertSpaces = options.insertSpaces;
+
+            let currIndent;
+            let prevIndent;
+            let indentStep;
+
+            currIndent = leadWsCount(currLine, tabSize);
+            prevIndent = leadWsCount(prevLine, tabSize);
+            indentStep = insertSpaces ? indentSize : tabSize;
+
+            let target;
+            if (lineRequiresUnindent(currLine, doc)) {
+                if (lineRequiresNextIndent(prevLine, doc)) {
+                    // example {
+                    // }
+                    target = prevIndent;
+                } else {
+                    //     example
+                    // }
+                    target = prevIndent - indentStep;
+                    if (target < 0) {
+                        target = 0;
+                    }
+                }
+            }
+            else if (lineRequiresNextIndent(prevLine, doc)) {
+                target = prevIndent + indentStep;
+            }
+            else {
+                target = prevIndent;
+            }
+
+            // unify leading whitespace if it contains indents not of our tab/space mode
+            let txt = currLine.text;
+            let end = currLine.firstNonWhitespaceCharacterIndex;
+            let validWs = insertSpaces ? 32 : 9;
+            // diff can be zero here, but we may need to replace spaces with tabs and still have a diff
+            for (let i = 0; i < end; i++) {
+                if (txt.charCodeAt(i) !== validWs) {
+                    // Leading whitespace contains a whitespace char of the opposite type
+                    // Replace the whole whitespace from start of line with the proper number of our
+                    // ws char
+                    editor.edit(function(builder) {
+                        builder.replace(new vscode.Range(cursorLine, 0, cursorLine, end), insertSpaces
+                        ? ' '.repeat(target)
+                        : '\t'.repeat(Math.floor(target/tabSize)));
+                    })
+                    .then(function() {
+                        let sel = editor.selection;
+                        if (!sel.isEmpty) {
+                            editor.selection = new vscode.Selection(sel.end, sel.end);
+                        }
+                    });
+                    return;
+                }
+            }
+
+            let diff = (currIndent - target); // diff is always in spaces
+            if (diff == 0) {
+                // business as usual
+                editor.edit(function(builder) {
+                    builder.insert(editor.selection.active, (
+                        // diff == 0 : Normal indent
+                        insertSpaces? ' '.repeat(-diff) : '\t'.repeat(Math.floor((-diff) / tabSize))
+                    ));
+                });
+            } else if (diff > 0) {
+                // overindented - delete some spaces
+                editor.edit(function(builder) {
+                    builder.insert(new vscode.Position(cursorLine, currIndent), (
+                        // diff < 0 : under-indented, add some spaces
+                        insertSpaces? ' '.repeat(-diff + (diff == 0? 1 : 0)) : '\t'.repeat(Math.floor((-diff) / tabSize) + (diff == 0? 1 : 0))
+                    ));
+                });
+            } else {
+                editor.edit(function(builder) {
+                    builder.insert(new vscode.Position(cursorLine, 0), (
+                        // diff < 0 : under-indented, add some spaces
+                        insertSpaces? ' '.repeat(-diff) : '\t'.repeat(Math.floor((-diff) / tabSize))
+                    ));
+                });
+            }
+        } catch(e) {
+            console.error("Exception:", e);
         }
-        else {
-            // diff < 0 : under-indented, add some spaces
-            editor.edit(function(builder) {
-                builder.insert(new vscode.Position(cursorLine, 0), insertSpaces
-                ? ' '.repeat(-diff)
-                : '\t'.repeat(Math.floor((-diff) / tabSize)));
-            });
-        }
-    } catch(e) {
-        console.error("Exception:", e);
-    }
     });
 }
-


### PR DESCRIPTION
Handle when diff = 0, diff > 0, and diff < 0.
When no diff or diff > 0, we indent as usual, when diff less than 0, we indent into calculated position based on previous one.

This might be different than this project intent. But, anyway I create this pull request.